### PR TITLE
Subscriptions

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,7 @@
 {
   "plugins": [
     "syntax-async-functions",
+    "syntax-async-generators",
     "transform-class-properties",
     "transform-flow-strip-types",
     "transform-object-rest-spread",

--- a/.eslintrc
+++ b/.eslintrc
@@ -70,7 +70,7 @@
     "eqeqeq": ["error", "smart"],
     "func-names": 0,
     "func-style": 0,
-    "generator-star-spacing": [2, {"before": true, "after": false}],
+    "generator-star-spacing": [2, {"before": false, "after": true}],
     "guard-for-in": 2,
     "handle-callback-err": [2, "error"],
     "id-length": 0,

--- a/package.json
+++ b/package.json
@@ -36,13 +36,14 @@
     "prepublish": ". ./resources/prepublish.sh"
   },
   "dependencies": {
-    "iterall": "1.0.3"
+    "iterall": "1.1.0"
   },
   "devDependencies": {
     "babel-cli": "6.24.1",
     "babel-eslint": "7.2.3",
     "babel-plugin-check-es2015-constants": "6.22.0",
     "babel-plugin-syntax-async-functions": "6.13.0",
+    "babel-plugin-syntax-async-generators": "6.13.0",
     "babel-plugin-transform-class-properties": "6.24.1",
     "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
     "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "prepublish": ". ./resources/prepublish.sh"
   },
   "dependencies": {
-    "iterall": "1.1.0"
+    "iterall": "1.1.1"
   },
   "devDependencies": {
     "babel-cli": "6.24.1",

--- a/src/execution/__tests__/lists-test.js
+++ b/src/execution/__tests__/lists-test.js
@@ -76,7 +76,7 @@ describe('Execute: Accepts any iterable as list value', () => {
     { data: { nest: { test: [ 'apple', 'banana', 'coconut' ] } } }
   ));
 
-  function *yieldItems() {
+  function* yieldItems() {
     yield 'one';
     yield 2;
     yield true;

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -83,7 +83,7 @@ import type {
  * Namely, schema of the type system that is currently executing,
  * and the fragments defined in the query document
  */
-type ExecutionContext = {
+export type ExecutionContext = {
   schema: GraphQLSchema;
   fragments: {[key: string]: FragmentDefinitionNode};
   rootValue: mixed;
@@ -186,8 +186,11 @@ export function responsePathAsArray(
   return flattened.reverse();
 }
 
-
-function addPath(prev: ResponsePath, key: string | number) {
+/**
+ * Given a ResponsePath and a key, return a new ResponsePath containing the
+ * new key.
+ */
+export function addPath(prev: ResponsePath, key: string | number) {
   return { prev, key };
 }
 
@@ -197,7 +200,7 @@ function addPath(prev: ResponsePath, key: string | number) {
  *
  * Throws a GraphQLError if a valid execution context cannot be created.
  */
-function buildExecutionContext(
+export function buildExecutionContext(
   schema: GraphQLSchema,
   document: DocumentNode,
   rootValue: mixed,
@@ -283,7 +286,7 @@ function executeOperation(
 /**
  * Extracts the root type of the operation from the schema.
  */
-function getOperationRootType(
+export function getOperationRootType(
   schema: GraphQLSchema,
   operation: OperationDefinitionNode
 ): GraphQLObjectType {
@@ -411,7 +414,7 @@ function executeFields(
  * returns an Interface or Union type, the "runtime type" will be the actual
  * Object type returned by that field.
  */
-function collectFields(
+export function collectFields(
   exeContext: ExecutionContext,
   runtimeType: GraphQLObjectType,
   selectionSet: SelectionSetNode,
@@ -1184,7 +1187,7 @@ function getPromise<T>(value: Promise<T> | mixed): Promise<T> | void {
  * added to the query type, but that would require mutating type
  * definitions, which would cause issues.
  */
-function getFieldDef(
+export function getFieldDef(
   schema: GraphQLSchema,
   parentType: GraphQLObjectType,
   fieldName: string

--- a/src/execution/execute.js
+++ b/src/execution/execute.js
@@ -120,22 +120,6 @@ export function execute(
   variableValues?: ?{[key: string]: mixed},
   operationName?: ?string
 ): Promise<ExecutionResult> {
-  invariant(schema, 'Must provide schema');
-  invariant(document, 'Must provide document');
-  invariant(
-    schema instanceof GraphQLSchema,
-    'Schema must be an instance of GraphQLSchema. Also ensure that there are ' +
-    'not multiple versions of GraphQL installed in your node_modules directory.'
-  );
-
-  // Variables, if provided, must be an object.
-  invariant(
-    !variableValues || typeof variableValues === 'object',
-    'Variables must be provided as an Object where each property is a ' +
-    'variable value. Perhaps look to see if an unparsed JSON string ' +
-    'was provided.'
-  );
-
   // If a valid context cannot be created due to incorrect arguments,
   // this will throw an error.
   const context = buildExecutionContext(
@@ -208,6 +192,22 @@ export function buildExecutionContext(
   rawVariableValues: ?{[key: string]: mixed},
   operationName: ?string
 ): ExecutionContext {
+  invariant(schema, 'Must provide schema');
+  invariant(document, 'Must provide document');
+  invariant(
+    schema instanceof GraphQLSchema,
+    'Schema must be an instance of GraphQLSchema. Also ensure that there are ' +
+    'not multiple versions of GraphQL installed in your node_modules directory.'
+  );
+
+  // Variables, if provided, must be an object.
+  invariant(
+    !rawVariableValues || typeof rawVariableValues === 'object',
+    'Variables must be provided as an Object where each property is a ' +
+    'variable value. Perhaps look to see if an unparsed JSON string ' +
+    'was provided.'
+  );
+
   const errors: Array<GraphQLError> = [];
   let operation: ?OperationDefinitionNode;
   const fragments: {[name: string]: FragmentDefinitionNode} =
@@ -584,20 +584,50 @@ function resolveField(
     return;
   }
 
-  const returnType = fieldDef.type;
   const resolveFn = fieldDef.resolve || defaultFieldResolver;
 
-  // The resolve function's optional third argument is a context value that
-  // is provided to every resolve function within an execution. It is commonly
-  // used to represent an authenticated user, or request-specific caches.
-  const context = exeContext.contextValue;
+  const info = buildResolveInfo(
+    exeContext,
+    fieldDef,
+    fieldNodes,
+    parentType,
+    path
+  );
 
+  // Get the resolve function, regardless of if its result is normal
+  // or abrupt (error).
+  const result = resolveFieldValueOrError(
+    exeContext,
+    fieldDef,
+    fieldNodes,
+    resolveFn,
+    source,
+    info
+  );
+
+  return completeValueCatchingError(
+    exeContext,
+    fieldDef.type,
+    fieldNodes,
+    info,
+    path,
+    result
+  );
+}
+
+export function buildResolveInfo(
+  exeContext: ExecutionContext,
+  fieldDef: GraphQLField<*, *>,
+  fieldNodes: Array<FieldNode>,
+  parentType: GraphQLObjectType,
+  path: ResponsePath
+): GraphQLResolveInfo {
   // The resolve function's optional fourth argument is a collection of
   // information about the current execution state.
-  const info: GraphQLResolveInfo = {
-    fieldName,
+  return {
+    fieldName: fieldNodes[0].name.value,
     fieldNodes,
-    returnType,
+    returnType: fieldDef.type,
     parentType,
     path,
     schema: exeContext.schema,
@@ -606,38 +636,16 @@ function resolveField(
     operation: exeContext.operation,
     variableValues: exeContext.variableValues,
   };
-
-  // Get the resolve function, regardless of if its result is normal
-  // or abrupt (error).
-  const result = resolveOrError(
-    exeContext,
-    fieldDef,
-    fieldNode,
-    resolveFn,
-    source,
-    context,
-    info
-  );
-
-  return completeValueCatchingError(
-    exeContext,
-    returnType,
-    fieldNodes,
-    info,
-    path,
-    result
-  );
 }
 
 // Isolates the "ReturnOrAbrupt" behavior to not de-opt the `resolveField`
 // function. Returns the result of resolveFn or the abrupt-return Error object.
-function resolveOrError<TSource, TContext>(
+export function resolveFieldValueOrError<TSource>(
   exeContext: ExecutionContext,
-  fieldDef: GraphQLField<TSource, TContext>,
-  fieldNode: FieldNode,
-  resolveFn: GraphQLFieldResolver<TSource, TContext>,
+  fieldDef: GraphQLField<TSource, *>,
+  fieldNodes: Array<FieldNode>,
+  resolveFn: GraphQLFieldResolver<TSource, *>,
   source: TSource,
-  context: TContext,
   info: GraphQLResolveInfo
 ): Error | mixed {
   try {
@@ -646,9 +654,14 @@ function resolveOrError<TSource, TContext>(
     // TODO: find a way to memoize, in case this field is within a List type.
     const args = getArgumentValues(
       fieldDef,
-      fieldNode,
+      fieldNodes[0],
       exeContext.variableValues
     );
+
+    // The resolve function's optional third argument is a context value that
+    // is provided to every resolve function within an execution. It is commonly
+    // used to represent an authenticated user, or request-specific caches.
+    const context = exeContext.contextValue;
 
     return resolveFn(source, args, context, info);
   } catch (error) {

--- a/src/execution/values.js
+++ b/src/execution/values.js
@@ -192,7 +192,7 @@ function coerceValue(type: GraphQLInputType, value: mixed): mixed {
     const itemType = type.ofType;
     if (isCollection(_value)) {
       const coercedValues = [];
-      const valueIter = createIterator(_value);
+      const valueIter = createIterator((_value: any));
       if (!valueIter) {
         return; // Intentionally return no value.
       }

--- a/src/subscription/__tests__/eventEmitterAsyncIterator-test.js
+++ b/src/subscription/__tests__/eventEmitterAsyncIterator-test.js
@@ -57,6 +57,8 @@ describe('eventEmitterAsyncIterator', () => {
     expect(await i5).to.deep.equal({ done: true, value: undefined });
 
     // And next returns empty completion value
-    expect(await iterator.next()).to.deep.equal({ done: true, value: undefined });
+    expect(await iterator.next()).to.deep.equal(
+      { done: true, value: undefined }
+    );
   });
 });

--- a/src/subscription/__tests__/eventEmitterAsyncIterator-test.js
+++ b/src/subscription/__tests__/eventEmitterAsyncIterator-test.js
@@ -1,0 +1,62 @@
+/**
+ *  Copyright (c) 2017, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+
+import EventEmitter from 'events';
+import eventEmitterAsyncIterator from './eventEmitterAsyncIterator';
+
+describe('eventEmitterAsyncIterator', () => {
+
+  it('subscribe async-iterator mock', async () => {
+    // Create an AsyncIterator from an EventEmitter
+    const emitter = new EventEmitter();
+    const iterator = eventEmitterAsyncIterator(emitter, 'publish');
+
+    // Queue up publishes
+    expect(emitter.emit('publish', 'Apple')).to.equal(true);
+    expect(emitter.emit('publish', 'Banana')).to.equal(true);
+
+    // Read payloads
+    expect(await iterator.next()).to.deep.equal(
+      { done: false, value: 'Apple' }
+    );
+    expect(await iterator.next()).to.deep.equal(
+      { done: false, value: 'Banana' }
+    );
+
+    // Read ahead
+    const i3 = iterator.next().then(x => x);
+    const i4 = iterator.next().then(x => x);
+
+    // Publish
+    expect(emitter.emit('publish', 'Coconut')).to.equal(true);
+    expect(emitter.emit('publish', 'Durian')).to.equal(true);
+
+    // Await out of order to get correct results
+    expect(await i4).to.deep.equal({ done: false, value: 'Durian'});
+    expect(await i3).to.deep.equal({ done: false, value: 'Coconut'});
+
+    // Read ahead
+    const i5 = iterator.next().then(x => x);
+
+    // Terminate emitter
+    await iterator.return();
+
+    // Publish is not caught after terminate
+    expect(emitter.emit('publish', 'Fig')).to.equal(false);
+
+    // Find that cancelled read-ahead got a "done" result
+    expect(await i5).to.deep.equal({ done: true, value: undefined });
+
+    // And next returns empty completion value
+    expect(await iterator.next()).to.deep.equal({ done: true, value: undefined });
+  });
+});

--- a/src/subscription/__tests__/eventEmitterAsyncIterator.js
+++ b/src/subscription/__tests__/eventEmitterAsyncIterator.js
@@ -1,0 +1,74 @@
+/**
+ *  Copyright (c) 2017, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+
+import type EventEmitter from 'events';
+
+const ASYNC_ITERATOR_SYMBOL =
+  typeof Symbol === 'function' && Symbol.asyncIterator || '@@asyncIterator';
+
+/**
+ * Create an AsyncIterator from an EventEmitter. Useful for mocking a
+ * PubSub system for tests.
+ */
+export default function eventEmitterAsyncIterator(
+  eventEmitter: EventEmitter,
+  eventName: string
+): AsyncIterator<mixed> {
+  let pullQueue = [];
+  let pushQueue = [];
+  let listening = true;
+  eventEmitter.addListener(eventName, pushValue);
+
+  function pushValue(event) {
+    if (pullQueue.length !== 0) {
+      pullQueue.shift()({ value: event, done: false });
+    } else {
+      pushQueue.push(event);
+    }
+  }
+
+  function pullValue() {
+    return new Promise(resolve => {
+      if (pushQueue.length !== 0) {
+        resolve({ value: pushQueue.shift(), done: false });
+      } else {
+        pullQueue.push(resolve);
+      }
+    });
+  }
+
+  function emptyQueue() {
+    if (listening) {
+      listening = false;
+      eventEmitter.removeListener(eventName, pushValue);
+      pullQueue.forEach(resolve => resolve({ value: undefined, done: true }));
+      pullQueue.length = 0;
+      pushQueue.length = 0;
+    }
+  }
+
+  return {
+    next() {
+      return listening ? pullValue() : this.return();
+    },
+    return() {
+      emptyQueue();
+      return Promise.resolve({ value: undefined, done: true });
+    },
+    throw(error) {
+      emptyQueue();
+      return Promise.reject(error);
+    },
+    [ASYNC_ITERATOR_SYMBOL]() {
+      return this;
+    },
+  };
+}

--- a/src/subscription/__tests__/eventEmitterAsyncIterator.js
+++ b/src/subscription/__tests__/eventEmitterAsyncIterator.js
@@ -10,9 +10,7 @@
  */
 
 import type EventEmitter from 'events';
-
-const ASYNC_ITERATOR_SYMBOL =
-  typeof Symbol === 'function' && Symbol.asyncIterator || '@@asyncIterator';
+import { $$asyncIterator } from 'iterall';
 
 /**
  * Create an AsyncIterator from an EventEmitter. Useful for mocking a
@@ -22,8 +20,8 @@ export default function eventEmitterAsyncIterator(
   eventEmitter: EventEmitter,
   eventName: string
 ): AsyncIterator<mixed> {
-  let pullQueue = [];
-  let pushQueue = [];
+  const pullQueue = [];
+  const pushQueue = [];
   let listening = true;
   eventEmitter.addListener(eventName, pushValue);
 
@@ -67,7 +65,7 @@ export default function eventEmitterAsyncIterator(
       emptyQueue();
       return Promise.reject(error);
     },
-    [ASYNC_ITERATOR_SYMBOL]() {
+    [$$asyncIterator]() {
       return this;
     },
   };

--- a/src/subscription/__tests__/mapAsyncIterator-test.js
+++ b/src/subscription/__tests__/mapAsyncIterator-test.js
@@ -43,7 +43,7 @@ describe('mapAsyncIterator', () => {
       yield 3;
     }
 
-    const doubles = mapAsyncIterator(source(), async (x) => await x + x);
+    const doubles = mapAsyncIterator(source(), async x => await x + x);
 
     expect(
       await doubles.next()
@@ -143,7 +143,7 @@ describe('mapAsyncIterator', () => {
     // Throw error
     let caughtError;
     try {
-      await doubles.throw('ouch')
+      await doubles.throw('ouch');
     } catch (e) {
       caughtError = e;
     }

--- a/src/subscription/__tests__/mapAsyncIterator-test.js
+++ b/src/subscription/__tests__/mapAsyncIterator-test.js
@@ -1,0 +1,193 @@
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import mapAsyncIterator from '../mapAsyncIterator';
+
+describe('mapAsyncIterator', () => {
+
+  it('maps over async values', async () => {
+    async function* source() {
+      yield 1;
+      yield 2;
+      yield 3;
+    }
+
+    const doubles = mapAsyncIterator(source(), x => x + x);
+
+    expect(
+      await doubles.next()
+    ).to.deep.equal({ value: 2, done: false });
+    expect(
+      await doubles.next()
+    ).to.deep.equal({ value: 4, done: false });
+    expect(
+      await doubles.next()
+    ).to.deep.equal({ value: 6, done: false });
+    expect(
+      await doubles.next()
+    ).to.deep.equal({ value: undefined, done: true });
+  });
+
+  it('maps over async values with async function', async () => {
+    async function* source() {
+      yield 1;
+      yield 2;
+      yield 3;
+    }
+
+    const doubles = mapAsyncIterator(source(), async (x) => await x + x);
+
+    expect(
+      await doubles.next()
+    ).to.deep.equal({ value: 2, done: false });
+    expect(
+      await doubles.next()
+    ).to.deep.equal({ value: 4, done: false });
+    expect(
+      await doubles.next()
+    ).to.deep.equal({ value: 6, done: false });
+    expect(
+      await doubles.next()
+    ).to.deep.equal({ value: undefined, done: true });
+  });
+
+  it('allows returning early from async values', async () => {
+    async function* source() {
+      yield 1;
+      yield 2;
+      yield 3;
+    }
+
+    const doubles = mapAsyncIterator(source(), x => x + x);
+
+    expect(
+      await doubles.next()
+    ).to.deep.equal({ value: 2, done: false });
+    expect(
+      await doubles.next()
+    ).to.deep.equal({ value: 4, done: false });
+
+    // Early return
+    expect(
+      await doubles.return()
+    ).to.deep.equal({ value: undefined, done: true });
+
+    // Subsequent nexts
+    expect(
+      await doubles.next()
+    ).to.deep.equal({ value: undefined, done: true });
+    expect(
+      await doubles.next()
+    ).to.deep.equal({ value: undefined, done: true });
+  });
+
+  it('passes through early return from async values', async () => {
+    async function* source() {
+      try {
+        yield 1;
+        yield 2;
+        yield 3;
+      } finally {
+        yield 'done';
+        yield 'last';
+      }
+    }
+
+    const doubles = mapAsyncIterator(source(), x => x + x);
+
+    expect(
+      await doubles.next()
+    ).to.deep.equal({ value: 2, done: false });
+    expect(
+      await doubles.next()
+    ).to.deep.equal({ value: 4, done: false });
+
+    // Early return
+    expect(
+      await doubles.return()
+    ).to.deep.equal({ value: 'donedone', done: false });
+
+    // Subsequent nexts may yield from finally block
+    expect(
+      await doubles.next()
+    ).to.deep.equal({ value: 'lastlast', done: false });
+    expect(
+      await doubles.next()
+    ).to.deep.equal({ value: undefined, done: true });
+  });
+
+  it('allows throwing errors through async generators', async () => {
+    async function* source() {
+      yield 1;
+      yield 2;
+      yield 3;
+    }
+
+    const doubles = mapAsyncIterator(source(), x => x + x);
+
+    expect(
+      await doubles.next()
+    ).to.deep.equal({ value: 2, done: false });
+    expect(
+      await doubles.next()
+    ).to.deep.equal({ value: 4, done: false });
+
+    // Throw error
+    let caughtError;
+    try {
+      await doubles.throw('ouch')
+    } catch (e) {
+      caughtError = e;
+    }
+    expect(caughtError).to.equal('ouch');
+
+    expect(
+      await doubles.next()
+    ).to.deep.equal({ value: undefined, done: true });
+    expect(
+      await doubles.next()
+    ).to.deep.equal({ value: undefined, done: true });
+  });
+
+  it('passes through caught errors through async generators', async () => {
+    async function* source() {
+      try {
+        yield 1;
+        yield 2;
+        yield 3;
+      } catch (e) {
+        yield e;
+      }
+    }
+
+    const doubles = mapAsyncIterator(source(), x => x + x);
+
+    expect(
+      await doubles.next()
+    ).to.deep.equal({ value: 2, done: false });
+    expect(
+      await doubles.next()
+    ).to.deep.equal({ value: 4, done: false });
+
+    // Throw error
+    expect(
+      await doubles.throw('ouch')
+    ).to.deep.equal({ value: 'ouchouch', done: false });
+
+    expect(
+      await doubles.next()
+    ).to.deep.equal({ value: undefined, done: true });
+    expect(
+      await doubles.next()
+    ).to.deep.equal({ value: undefined, done: true });
+  });
+
+});

--- a/src/subscription/__tests__/subscribe-test.js
+++ b/src/subscription/__tests__/subscribe-test.js
@@ -20,7 +20,6 @@ import {
   GraphQLBoolean,
   GraphQLInt,
   GraphQLString,
-  GraphQLNonNull,
 } from '../../type';
 
 

--- a/src/subscription/__tests__/subscribe-test.js
+++ b/src/subscription/__tests__/subscribe-test.js
@@ -1,0 +1,215 @@
+/**
+ *  Copyright (c) 2015, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+import { expect } from 'chai';
+import { describe, it } from 'mocha';
+import EventEmitter from 'events';
+import eventEmitterAsyncIterator from './eventEmitterAsyncIterator';
+import {subscribe} from '../subscribe';
+import { parse } from '../../language';
+import {
+  GraphQLSchema,
+  GraphQLObjectType,
+  GraphQLList,
+  GraphQLBoolean,
+  GraphQLInt,
+  GraphQLString,
+  GraphQLNonNull,
+} from '../../type';
+
+
+describe('Subscribe', () => {
+
+  const EmailType = new GraphQLObjectType({
+    name: 'Email',
+    fields: {
+      from: { type: GraphQLString },
+      subject: { type: GraphQLString },
+      message: { type: GraphQLString },
+      unread: { type: GraphQLBoolean },
+    }
+  });
+
+  const InboxType = new GraphQLObjectType({
+    name: 'Inbox',
+    fields: {
+      total: {
+        type: GraphQLInt,
+        resolve: inbox => inbox.emails.length,
+      },
+      unread: {
+        type: GraphQLInt,
+        resolve: inbox => inbox.emails.filter(email => email.unread).length,
+      },
+      emails: { type: new GraphQLList(EmailType) },
+    }
+  });
+
+  const QueryType = new GraphQLObjectType({
+    name: 'Query',
+    fields: {
+      inbox: { type: InboxType },
+    }
+  });
+
+  const EmailEventType = new GraphQLObjectType({
+    name: 'EmailEvent',
+    fields: {
+      email: { type: EmailType },
+      inbox: { type: InboxType },
+    }
+  });
+
+  const SubscriptionType = new GraphQLObjectType({
+    name: 'Subscription',
+    fields: {
+      importantEmail: { type: EmailEventType },
+    }
+  });
+
+  const emailSchema = new GraphQLSchema({
+    query: QueryType,
+    subscription: SubscriptionType
+  });
+
+  it('produces a payload per subscription event', async () => {
+
+    const pubsub = new EventEmitter();
+
+    const data = {
+      inbox: {
+        emails: [
+          {
+            from: 'joe@graphql.org',
+            subject: 'Hello',
+            message: 'Hello World',
+            unread: false,
+          },
+        ],
+      },
+      importantEmail() {
+        return eventEmitterAsyncIterator(pubsub, 'importantEmail');
+      }
+    };
+
+    function sendImportantEmail(newEmail) {
+      data.inbox.emails.push(newEmail);
+      // Returns true if the event was consumed by a subscriber.
+      return pubsub.emit('importantEmail', {
+        importantEmail: {
+          email: newEmail,
+          inbox: data.inbox,
+        }
+      });
+    }
+
+    const ast = parse(`
+      subscription ($priority: Int = 0) {
+        importantEmail(priority: $priority) {
+          email {
+            from
+            subject
+          }
+          inbox {
+            unread
+            total
+          }
+        }
+      }
+    `);
+
+    // GraphQL `subscribe` has the same call signature as `execute`, but returns
+    // AsyncIterator instead of Promise.
+    const subscription = subscribe(
+      emailSchema,
+      ast,
+      data,
+      null, // context
+      { priority: 1 }
+    );
+
+    // Wait for the next subscription payload.
+    const payload = subscription.next();
+
+    // A new email arrives!
+    expect(sendImportantEmail({
+      from: 'yuzhi@graphql.org',
+      subject: 'Alright',
+      message: 'Tests are good',
+      unread: true,
+    })).to.equal(true);
+
+    // The previously waited on payload now has a value.
+    expect(await payload).to.deep.equal({
+      done: false,
+      value: {
+        data: {
+          importantEmail: {
+            email: {
+              from: 'yuzhi@graphql.org',
+              subject: 'Alright',
+            },
+            inbox: {
+              unread: 1,
+              total: 2,
+            },
+          },
+        },
+      },
+    });
+
+    // Another new email arrives, before subscription.next() is called.
+    expect(sendImportantEmail({
+      from: 'hyo@graphql.org',
+      subject: 'Tools',
+      message: 'I <3 making things',
+      unread: true,
+    })).to.equal(true);
+
+    // The next waited on payload will have a value.
+    expect(await subscription.next()).to.deep.equal({
+      done: false,
+      value: {
+        data: {
+          importantEmail: {
+            email: {
+              from: 'hyo@graphql.org',
+              subject: 'Tools',
+            },
+            inbox: {
+              unread: 2,
+              total: 3,
+            },
+          },
+        },
+      },
+    });
+
+    // The client decides to disconnect.
+    expect(await subscription.return()).to.deep.equal({
+      done: true,
+      value: undefined,
+    });
+
+    // Which may result in disconnecting upstream services as well.
+    expect(sendImportantEmail({
+      from: 'adam@graphql.org',
+      subject: 'Important',
+      message: 'Read me please',
+      unread: true,
+    })).to.equal(false); // No more listeners.
+
+    // Awaiting a subscription after closing it results in completed results.
+    expect(await subscription.next()).to.deep.equal({
+      done: true,
+      value: undefined,
+    });
+  });
+
+});

--- a/src/subscription/mapAsyncIterator.js
+++ b/src/subscription/mapAsyncIterator.js
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) 2017, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+
+const ASYNC_ITERATOR_SYMBOL =
+  typeof Symbol === 'function' && Symbol.asyncIterator || '@@asyncIterator';
+
+/**
+ * Given an AsyncIterator and a callback function, return a new AsyncIterator
+ * which produces values mapped via calling the callback function.
+ */
+export default function mapAsyncIterator<T, U>(
+  iterator: AsyncIterator<T>,
+  callback: (value: T) => U
+): AsyncIterator<U> {
+  function mapResult(result) {
+    return result.done ?
+      result :
+      Promise.resolve(callback(result.value)).then(
+        mapped => ({ value: mapped, done: false })
+      );
+  }
+
+  return {
+    next() {
+      return iterator.next().then(mapResult);
+    },
+    return() {
+      if (typeof iterator.return === 'function') {
+        return iterator.return().then(mapResult);
+      }
+      return Promise.resolve({ value: undefined, done: true });
+    },
+    throw(error) {
+      if (typeof iterator.throw === 'function') {
+        return iterator.throw(error).then(mapResult);
+      }
+      return Promise.reject(error);
+    },
+    [ASYNC_ITERATOR_SYMBOL]() {
+      return this;
+    },
+  };
+}

--- a/src/subscription/mapAsyncIterator.js
+++ b/src/subscription/mapAsyncIterator.js
@@ -9,17 +9,20 @@
  * @flow
  */
 
-const ASYNC_ITERATOR_SYMBOL =
-  typeof Symbol === 'function' && Symbol.asyncIterator || '@@asyncIterator';
+import { $$asyncIterator, getAsyncIterator } from 'iterall';
 
 /**
- * Given an AsyncIterator and a callback function, return a new AsyncIterator
+ * Given an AsyncIterable and a callback function, return an AsyncIterator
  * which produces values mapped via calling the callback function.
  */
 export default function mapAsyncIterator<T, U>(
-  iterator: AsyncIterator<T>,
+  iterable: AsyncIterable<T>,
   callback: (value: T) => U
 ): AsyncIterator<U> {
+  // Fixes a temporary issue with Regenerator/Babel
+  // https://github.com/facebook/regenerator/pull/290
+  const iterator = iterable.next ? (iterable: any) : getAsyncIterator(iterable);
+
   function mapResult(result) {
     return result.done ?
       result :
@@ -44,7 +47,7 @@ export default function mapAsyncIterator<T, U>(
       }
       return Promise.reject(error);
     },
-    [ASYNC_ITERATOR_SYMBOL]() {
+    [$$asyncIterator]() {
       return this;
     },
   };

--- a/src/subscription/mapAsyncIterator.js
+++ b/src/subscription/mapAsyncIterator.js
@@ -19,9 +19,7 @@ export default function mapAsyncIterator<T, U>(
   iterable: AsyncIterable<T>,
   callback: (value: T) => U
 ): AsyncIterator<U> {
-  // Fixes a temporary issue with Regenerator/Babel
-  // https://github.com/facebook/regenerator/pull/290
-  const iterator = iterable.next ? (iterable: any) : getAsyncIterator(iterable);
+  const iterator = getAsyncIterator(iterable);
 
   function mapResult(result) {
     return result.done ?

--- a/src/subscription/subscribe.js
+++ b/src/subscription/subscribe.js
@@ -1,0 +1,184 @@
+/**
+ * Copyright (c) 2017, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ *
+ * @flow
+ */
+
+import {
+  addPath,
+  buildExecutionContext,
+  collectFields,
+  defaultFieldResolver,
+  execute,
+  getFieldDef,
+  getOperationRootType,
+} from '../execution/execute';
+import { getArgumentValues } from '../execution/values';
+import { GraphQLSchema } from '../type/schema';
+import invariant from '../jsutils/invariant';
+import mapAsyncIterator from './mapAsyncIterator';
+
+import type {
+  ExecutionContext,
+  ExecutionResult,
+} from '../execution/execute';
+import type {
+  DocumentNode,
+  OperationDefinitionNode,
+} from '../language/ast';
+import type { GraphQLResolveInfo } from '../type/definition';
+
+
+/**
+ * Implements the "Subscribing to request" section of the GraphQL specification.
+ *
+ * Returns an AsyncIterator
+ *
+ * If the arguments to this function do not result in a legal execution context,
+ * a GraphQLError will be thrown immediately explaining the invalid input.
+ */
+export function subscribe(
+  schema: GraphQLSchema,
+  document: DocumentNode,
+  rootValue?: mixed,
+  contextValue?: mixed,
+  variableValues?: ?{[key: string]: mixed},
+  operationName?: ?string,
+): AsyncIterator<ExecutionResult> {
+  // Note: these invariants are identical to execute.js
+  invariant(schema, 'Must provide schema');
+  invariant(document, 'Must provide document');
+  invariant(
+    schema instanceof GraphQLSchema,
+    'Schema must be an instance of GraphQLSchema. Also ensure that there are ' +
+    'not multiple versions of GraphQL installed in your node_modules directory.'
+  );
+
+  // Variables, if provided, must be an object.
+  invariant(
+    !variableValues || typeof variableValues === 'object',
+    'Variables must be provided as an Object where each property is a ' +
+    'variable value. Perhaps look to see if an unparsed JSON string ' +
+    'was provided.'
+  );
+
+  // If a valid context cannot be created due to incorrect arguments,
+  // this will throw an error.
+  const exeContext = buildExecutionContext(
+    schema,
+    document,
+    rootValue,
+    contextValue,
+    variableValues,
+    operationName
+  );
+
+  // Call the `subscribe()` resolver or the default resolver to produce an
+  // AsyncIterable yielding raw payloads.
+  const subscription = resolveSubscription(
+    exeContext,
+    exeContext.operation,
+    rootValue
+  );
+
+  // For each payload yielded from a subscription, map it over the normal
+  // GraphQL `execute` function, with `payload` as the rootValue.
+  return mapAsyncIterator(
+    subscription,
+    payload => execute(
+      schema,
+      document,
+      payload,
+      contextValue,
+      variableValues,
+      operationName
+    )
+  );
+}
+
+function resolveSubscription(
+  exeContext: ExecutionContext,
+  operation: OperationDefinitionNode,
+  rootValue: mixed
+): AsyncIterator<mixed> {
+  // Note: this function is almost the same as executeOperation() and
+  // resolveField() with only a few minor differences.
+
+  const type = getOperationRootType(exeContext.schema, exeContext.operation);
+  const fields = collectFields(
+    exeContext,
+    type,
+    exeContext.operation.selectionSet,
+    Object.create(null),
+    Object.create(null)
+  );
+
+  const responseNames = Object.keys(fields);
+  invariant(
+    responseNames.length === 1,
+    'A subscription must contain exactly one field.'
+  );
+  const responseName = responseNames[0];
+  const fieldNodes = fields[responseName];
+  const fieldPath = addPath(undefined, responseName);
+
+  const fieldNode = fieldNodes[0];
+  const fieldName = fieldNode.name.value;
+  const fieldDef = getFieldDef(exeContext.schema, type, fieldName);
+  invariant(
+    fieldDef,
+    'This subscription is not defined by the schema.'
+  );
+
+  // TODO: make GraphQLSubscription flow type special to support defining these?
+  const resolveFn = (fieldDef: any).subscribe || defaultFieldResolver;
+
+  // The resolve function's optional third argument is a context value that
+  // is provided to every resolve function within an execution. It is commonly
+  // used to represent an authenticated user, or request-specific caches.
+  const context = exeContext.contextValue;
+
+  // The resolve function's optional fourth argument is a collection of
+  // information about the current execution state.
+  const info: GraphQLResolveInfo = {
+    fieldName,
+    fieldNodes,
+    returnType: fieldDef.type,
+    parentType: type,
+    path: fieldPath,
+    schema: exeContext.schema,
+    fragments: exeContext.fragments,
+    rootValue: exeContext.rootValue,
+    operation: exeContext.operation,
+    variableValues: exeContext.variableValues,
+  };
+
+  // Build a JS object of arguments from the field.arguments AST, using the
+  // variables scope to fulfill any variable references.
+  const args = getArgumentValues(
+    fieldDef,
+    fieldNode,
+    exeContext.variableValues
+  );
+
+  // TODO: resolveFn could throw!
+  const subscription = resolveFn(rootValue, args, context, info);
+
+  invariant(
+    isIterable(subscription),
+    'Subscription must return async-iterator.'
+  );
+
+  return subscription;
+}
+
+function isIterable(value) {
+  return typeof value === 'object' &&
+    value !== null &&
+    typeof value.next === 'function';
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -309,6 +309,10 @@ babel-plugin-syntax-async-functions@6.13.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz#cad9cad1191b5ad634bf30ae0872391e0647be95"
 
+babel-plugin-syntax-async-generators@6.13.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-async-generators/-/babel-plugin-syntax-async-generators-6.13.0.tgz#6bc963ebb16eccbae6b92b596eb7f35c342a8b9a"
+
 babel-plugin-syntax-class-properties@^6.8.0:
   version "6.13.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-class-properties/-/babel-plugin-syntax-class-properties-6.13.0.tgz#d7eb23b79a317f8543962c505b827c7d6cac27de"
@@ -770,13 +774,13 @@ dashdash@^1.12.0:
   dependencies:
     assert-plus "^1.0.0"
 
-debug@2.6.0:
+debug@2.6.0, debug@^2.2.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.0.tgz#bc596bcabe7617f11d9fa15361eded5608b8499b"
   dependencies:
     ms "0.7.2"
 
-debug@^2.1.1, debug@^2.2.0, debug@~2.2.0:
+debug@^2.1.1, debug@~2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.2.0.tgz#f87057e995b1a1f6ae6a4960664137bc56f039da"
   dependencies:
@@ -1518,9 +1522,9 @@ istanbul@^0.4.0:
     which "^1.1.1"
     wordwrap "^1.0.0"
 
-iterall@1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.0.3.tgz#e0b31958f835013c323ff0b10943829ac69aa4b7"
+iterall@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.1.1.tgz#f7f0af11e9a04ec6426260f5019d9fcca4d50214"
 
 jodid25519@^1.0.0:
   version "1.0.2"


### PR DESCRIPTION
I coded up a mostly working version of what I was talking about with @robzhu earlier today to use the [AsyncIterator](https://github.com/tc39/proposal-async-iteration) protocol to handle subscriptions.

This uses the same architectural model as [apollographql/graphql-subscriptions](https://github.com/apollographql/graphql-subscriptions) in that it provides a stateful in-process subscription, and on each "publish" then GraphQL's existing `execute()` function is called.

In the context of AsyncIterator this can be expressed as a "map" operation which I've implemented here and added some tests for.

The actual guts of the implementation are really not interesting at all - almost entirely recycled from functions in `execute.js`. In fact, perhaps going this direction would necessitate a minor refactoring of that file to reduce the obvious code duplication between the two and make this change even smaller.

To produce the pubsub AsyncIterator, a field on the root subscription type can provide a `subscribe` resolver function, or the default resolver function can be used, which allows for providing subscription functions via the rootObject - mirroring the existing pattern used for mutation fields.

Another idea that has come up is to have the ability to provide a global function (not defined in your schema) which is responsible for accepting a parsed GraphQL document and returning a corresponding pubsub AsyncIterator. That's effectively the design of [apollographql/graphql-subscriptions](https://github.com/apollographql/graphql-subscriptions) as it is now. I think this idea is actually just a subscriptions specific variant of the similar request in https://github.com/graphql/graphql-js/issues/733 - allowing a custom "default resolver" to apply. We could consider this idea separately and reap its value for all types in GraphQL, not just subscriptions!

There are some TODOs scattered around here - mostly highlighting places where errors during subscription setup are not being handled yet. What value should a failed subscription setup produce?